### PR TITLE
Remove default completion, mask API key, and set .scanoss permissions

### DIFF
--- a/backend/main/pkg/common/config/repository/config_repository_json_impl.go
+++ b/backend/main/pkg/common/config/repository/config_repository_json_impl.go
@@ -109,13 +109,14 @@ func (r *ConfigJsonRepository) createConfigFile() error {
 	// Check if the directory exists
 	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 		// Directory does not exist, create it
-		err := os.MkdirAll(dirPath, os.ModePerm)
+		err := os.MkdirAll(dirPath, 0700)
 		if err != nil {
 			return err
 		}
 	}
 
-	file, err := os.Create(r.configPath)
+	// Create the file with read/write permissions (owner and group only)
+	file, err := os.OpenFile(r.configPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		fmt.Printf("Failed to create configuration file: %v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -17,13 +17,13 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
-// go:embed all:frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 // Gets updated build time using -ldflags
 var version = ""
 
-// go:embed build/assets/icon.gif
+//go:embed build/assets/icon.gif
 var icon []byte
 
 func main() {


### PR DESCRIPTION
### **What**

 - Granted r/w permissions to .scanoss folder
 - Removed default completion sub-command
 - Masked API Key when configuring new one