### PR TITLE
feat: SP-1569 Add component info tooltip with url

### DIFF
--- a/frontend/src/components/Link.tsx
+++ b/frontend/src/components/Link.tsx
@@ -1,0 +1,15 @@
+import { BrowserOpenURL } from '../../wailsjs/runtime';
+
+export default function Link({ to }: { to: string }) {
+  return (
+    <a
+      onClick={(e) => {
+        e.preventDefault();
+        BrowserOpenURL(to);
+      }}
+      className="cursor-pointer text-blue-500 underline"
+    >
+      {to}
+    </a>
+  );
+}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 overflow-hidden rounded-md bg-black bg-opacity-60 px-3 py-1.5 text-xs text-primary-foreground backdrop-blur-lg animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/frontend/src/modules/files/components/ComponentDetailTooltip.tsx
+++ b/frontend/src/modules/files/components/ComponentDetailTooltip.tsx
@@ -1,0 +1,66 @@
+import clsx from 'clsx';
+import { entities } from 'wailsjs/go/models';
+
+import Link from '@/components/Link';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { MatchType, matchTypePresentation } from '@/modules/results/domain';
+
+interface ComponentDetailTooltipProps {
+  component: entities.ComponentDTO;
+}
+
+export default function ComponentDetailTooltip({
+  component,
+}: ComponentDetailTooltipProps) {
+  const matchPresentation = matchTypePresentation[component.id as MatchType];
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="cursor-pointer">
+          <div
+            className={clsx(
+              'text-lg font-bold leading-tight',
+              matchPresentation.accent
+            )}
+          >
+            {component.component}
+          </div>
+          <div>{component.purl?.[0]}</div>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" align="start" className="p-4">
+        <div className="flex flex-col gap-4">
+          {component.purl?.length ? (
+            <div>
+              <p className="font-medium">PURL</p>
+              <p className="text-muted-foreground">{component.purl?.[0]}</p>
+            </div>
+          ) : null}
+          <div>
+            <p className="font-medium">VERSION</p>
+            <p className="text-muted-foreground">{component.version}</p>
+          </div>
+          {component.licenses?.length ? (
+            <div>
+              <p className="font-medium">LICENSE</p>
+              <p className="text-muted-foreground">
+                {component.licenses?.[0].name}
+              </p>
+            </div>
+          ) : null}
+          {component.url && (
+            <div>
+              <p className="font-medium">URL</p>
+              <Link to={component.url} />
+            </div>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/src/modules/files/components/MatchInfoCard.tsx
+++ b/frontend/src/modules/files/components/MatchInfoCard.tsx
@@ -13,6 +13,7 @@ import ResultService from '@/modules/results/infra/service';
 import { useResults } from '@/modules/results/providers/ResultsProvider';
 
 import useLocalFilePath from '../hooks/useLocalFilePath';
+import ComponentDetailTooltip from './ComponentDetailTooltip';
 
 export default function MatchInfoCard() {
   const { results } = useResults();
@@ -49,17 +50,7 @@ export default function MatchInfoCard() {
       )}
     >
       <div className="flex flex-wrap items-center gap-8 text-sm">
-        <div>
-          <div
-            className={clsx(
-              'text-lg font-bold leading-tight',
-              matchPresentation.accent
-            )}
-          >
-            {component.component}
-          </div>
-          <div>{component.purl?.[0]}</div>
-        </div>
+        <ComponentDetailTooltip component={component} />
         {component.version && (
           <div>
             <div className={matchPresentation.muted}>Version</div>


### PR DESCRIPTION
## What
- Adds a tooltip that shows extra component information

## Screenshot
<img width="775" alt="image" src="https://github.com/user-attachments/assets/9b432c7b-35f9-4080-9c62-1b91613666ad">