### PR TITLE
Support launching from icon on windows.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,11 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	// Set cobra's "mousetrap text" to the blank string.
+	// On Windows, if this is non-blank, it will attempt to detect launch from icon (e.g. double clicking in explorer, a program menu icon, etc)
+	// and pop up a dialog saying that it's a CLI intended for use at a terminal & terminate.
+	cobra.MousetrapHelpText = ""
+
 	// We need the original wd to set the default values for the config.
 	// Otherwise, when running from a symlink, the default values will be incorrect.
 	var err error


### PR DESCRIPTION
As the comment describes, cobra will complain about being run from a non-terminal and exit, but it's totally reasonable to run that way now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled the pop-up warning message that appeared when launching the application from a graphical interface on Windows. The application will now exit silently in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->