### PR TITLE
SP-2553 Use platform-aware path splitting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -99,4 +99,3 @@ jobs:
         env:
           SCANOSS_API_KEY: ${{ secrets.SCANOSS_API_KEY }}
         run: go test -v ./... -tags=integration
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [0.7.2] 2025-05-01
+### Fixed
+- Fix splitting paths on Windows
+
 ## [0.7.1] 2025-04-28
 ### Fixed
-- Disabled the pop-up warning message that appeared when launching the application from a graphical interface on Windows.
+- Disable pop-up warning message that appeared when launching the application from a graphical interface on Windows.
 
-  
+
 ## [0.7.0] 2025-03-24
 
 ### Added
@@ -29,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Modified
 - Improve scanning performance
 
-  
+
 ## [0.6.4] 2025-03-18
 
 ### Fixed
@@ -40,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.3] 2025-03-12
 
 ### Fixed
-- Fix windows build 
+- Fix windows build
 
 ## [0.6.2] 2025-03-12
 

--- a/backend/repository/scanoss_settings_repository_json_impl.go
+++ b/backend/repository/scanoss_settings_repository_json_impl.go
@@ -346,7 +346,7 @@ func (r *ScanossSettingsJsonRepository) MatchesEffectiveScanningSkipPattern(path
 		isDir = fileInfo.IsDir()
 	}
 
-	pathParts := strings.Split(path, "/")
+	pathParts := utils.FullySplitPath(path)
 	return r.compiledMatcher.Match(pathParts, isDir)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file path handling to ensure correct splitting of paths on Windows systems.

- **Documentation**
	- Updated the changelog with a new entry for version 0.7.2 and revised the entry for version 0.7.1.
	- Made minor formatting and whitespace adjustments in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->