### PR TITLE
chore/SP-3687 Disables wfp output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6] 2025-11-11
+### Changed
+- Add `--no-wfp-output` flag to default scan options to disable WFP output
+
 ## [0.9.5] 2025-11-07
 ### Fixed
 - Fix macOS postinstall script where it was not properly handling the `--scan-root` argument.
@@ -197,3 +201,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.9.3]: https://github.com/scanoss/scanoss.cc/compare/v0.9.2...v0.9.3
 [0.9.4]: https://github.com/scanoss/scanoss.cc/compare/v0.9.3...v0.9.4
 [0.9.5]: https://github.com/scanoss/scanoss.cc/compare/v0.9.4...v0.9.5
+[0.9.6]: https://github.com/scanoss/scanoss.cc/compare/v0.9.5...v0.9.6

--- a/backend/entities/scan.go
+++ b/backend/entities/scan.go
@@ -55,7 +55,7 @@ var (
 		{"post-size", "P", 32, "Number of kilobytes to limit the post to while scanning (optional - default 32)", "Limits the size of each scan request to improve performance and reliability", "int", false, false},
 		{"timeout", "M", 180, "Timeout (in seconds) for API communication (optional - default 180)", "", "int", false, false},
 		{"retry", "R", 5, "Retry limit for API communication (optional - default 5)", "", "int", false, false},
-		{"no-wfp-output", "", false, "Skip WFP file generation", "", "bool", false, false},
+		{"no-wfp-output", "", true, "Skip WFP file generation", "", "bool", true, true},
 		{"dependencies", "D", false, "Add Dependency scanning", "", "bool", false, false},
 		{"dependencies-only", "", false, "Run Dependency scanning only", "", "bool", false, false},
 		{"sc-command", "", "", "Scancode command and path if required (optional - default scancode).", "", "string", false, false},

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -52,6 +52,7 @@ func NewScanCmd(scanService service.ScanService) *cobra.Command {
 
 			scanOptions := make([]string, 0)
 			scanOptions = append(scanOptions, "--quiet")
+			scanOptions = append(scanOptions, "--no-wfp-output")
 
 			var scanDirPath string
 

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -61,7 +61,6 @@ func TestScanCommand(t *testing.T) {
 		cmd.SetArgs([]string{
 			"/test/path",
 			"--output=results.json",
-			"--no-wfp-output",
 			"--threads=10",
 			"--format=json",
 		})
@@ -76,6 +75,7 @@ func TestScanCommand(t *testing.T) {
 		mockService.EXPECT().CheckDependencies().Return(nil)
 		mockService.EXPECT().Scan(mock.MatchedBy(func(args []string) bool {
 			expectedArgs := []string{
+				"--no-wfp-output",
 				"/test/path",
 				"--quiet",
 			}
@@ -96,7 +96,7 @@ func TestScanCommand(t *testing.T) {
 		mockService.EXPECT().CheckDependencies().Return(nil)
 		mockService.EXPECT().Scan(mock.MatchedBy(func(args []string) bool {
 			expectedArgs := []string{
-				"--files", "file1.go,file2.go",
+				"--files", "--no-wfp-output", "file1.go,file2.go",
 				"--quiet",
 			}
 			sort.Strings(args)
@@ -147,7 +147,6 @@ func TestScanCommand(t *testing.T) {
 		cmd := cmd.NewScanCmd(mockService)
 		cmd.SetArgs([]string{
 			"/test/path",
-			"--no-wfp-output",
 			"--dependencies",
 			"--debug",
 			"--trace",


### PR DESCRIPTION
## What's Changed

### Changed 
- Add `--no-wfp-output` flag to default scan options to disable WFP output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-wfp-output` option to the scan command to disable WFP output.

* **Behavior Changes**
  * The scan command now emits the `--no-wfp-output` setting by default, so WFP output is disabled unless explicitly overridden.

* **Documentation**
  * Updated changelog with a 0.9.6 entry noting the new option and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->