### PR TITLE
fix: add trailing new line when saving a .json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.7] 2025-11-14
+### Fixed
+- Add trailing new line when saving a .json file to comply with POSIX text file standards, fixes issue [#127](https://github.com/scanoss/scanoss.cc/issues/127)
+
 ## [0.9.6] 2025-11-11
 ### Changed
 - Add `--no-wfp-output` flag to default scan options to disable WFP output

--- a/internal/utils/file_utils_default_impl.go
+++ b/internal/utils/file_utils_default_impl.go
@@ -90,6 +90,9 @@ func JSONSerialize(in any) ([]byte, error) {
 		return nil, err
 	}
 
+	// Append newline to comply with POSIX text file standards
+	out = append(out, '\n')
+
 	return out, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON file formatting to include proper trailing newlines, ensuring compliance with POSIX text file standards and improved file consistency across different systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->