### PR TITLE
SP-4383: Environmental variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] 2026-05-21
+### Added
+- Added support for env variables (`SCANOSS_SCAN_URL`, `SCANOSS_API_KEY`)
+
 ## [0.13.1] 2026-05-20
 ### Fixed
 - Fixed bug where --input is overridden when --scan-root is not set
@@ -288,3 +292,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.1]: https://github.com/scanoss/scanoss.cc/compare/v0.12.0...v0.12.1
 [0.13.0]: https://github.com/scanoss/scanoss.cc/compare/v0.12.1...v0.13.0
 [0.13.1]: https://github.com/scanoss/scanoss.cc/compare/v0.13.0...v0.13.1
+[0.13.2]: https://github.com/scanoss/scanoss.cc/compare/v0.13.1...v0.13.2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -313,6 +313,9 @@ func (c *Config) setupLogger(debug bool) error {
 }
 
 func (c *Config) initializeConfigFile(cfgFile string) error {
+	viper.SetDefault("apiurl", DefaultAPIURL)
+	viper.SetDefault("apitoken", "")
+
 	if cfgFile != "" {
 		absCfgFile, _ := filepath.Abs(cfgFile)
 		log.Debug().Msgf("Using config file: %s", absCfgFile)
@@ -327,10 +330,6 @@ func (c *Config) initializeConfigFile(cfgFile string) error {
 	viper.SetConfigName(DEFAULT_CONFIG_FILE_NAME)
 	viper.SetConfigType(DEFAULT_CONFIG_FILE_TYPE)
 	viper.AddConfigPath(c.GetDefaultConfigFolder())
-
-	// Default values
-	viper.SetDefault("apiurl", DefaultAPIURL)
-	viper.SetDefault("apitoken", "")
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
@@ -352,6 +351,22 @@ func (c *Config) initializeConfigFile(cfgFile string) error {
 func (c *Config) initializeApiConfig(apiKey, apiUrl string) error {
 	c.SetApiToken(viper.GetString("apitoken"))
 	c.SetApiUrl(viper.GetString("apiurl"))
+
+	// Override with environmental variables
+	if apiUrl == "" {
+		if v := os.Getenv("SCANOSS_SCAN_URL"); v != "" {
+			c.mu.Lock()
+			c.apiUrl = v
+			c.mu.Unlock()
+		}
+	}
+	if apiKey == "" {
+		if v := os.Getenv("SCANOSS_API_KEY"); v != "" {
+			c.mu.Lock()
+			c.apiToken = v
+			c.mu.Unlock()
+		}
+	}
 
 	// Override with command line flags
 	if apiKey != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,55 @@ func initConfig(t *testing.T, scanRoot, inputFile, settingsFile, workDir string)
 	return cfg
 }
 
+func initConfigWithApiArgs(t *testing.T, apiKey, apiUrl string) *config.Config {
+	t.Helper()
+	config.ResetInstance()
+
+	f, err := os.CreateTemp("", "scanoss-cc-settings-*.json")
+	require.NoError(t, err)
+	_, err = f.WriteString(`{}`)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
+	cfg := config.GetInstance()
+	err = cfg.InitializeConfig(f.Name(), "", apiKey, apiUrl, "", "", "", false)
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestInitializeApiConfig(t *testing.T) {
+	t.Run("defaults when no env vars or CLI args", func(t *testing.T) {
+		cfg := initConfigWithApiArgs(t, "", "")
+		assert.Equal(t, config.DefaultAPIURL, cfg.GetApiUrl())
+		assert.Equal(t, "", cfg.GetApiToken())
+	})
+
+	t.Run("SCANOSS_SCAN_URL env var sets api url when no CLI url", func(t *testing.T) {
+		t.Setenv("SCANOSS_SCAN_URL", "https://custom.example.com")
+		cfg := initConfigWithApiArgs(t, "", "")
+		assert.Equal(t, "https://custom.example.com", cfg.GetApiUrl())
+	})
+
+	t.Run("CLI --apiUrl overrides SCANOSS_SCAN_URL env var", func(t *testing.T) {
+		t.Setenv("SCANOSS_SCAN_URL", "https://env.example.com")
+		cfg := initConfigWithApiArgs(t, "", "https://cli.example.com")
+		assert.Equal(t, "https://cli.example.com", cfg.GetApiUrl())
+	})
+
+	t.Run("SCANOSS_API_KEY env var sets api token when no CLI key", func(t *testing.T) {
+		t.Setenv("SCANOSS_API_KEY", "env-api-key")
+		cfg := initConfigWithApiArgs(t, "", "")
+		assert.Equal(t, "env-api-key", cfg.GetApiToken())
+	})
+
+	t.Run("CLI --apiKey overrides SCANOSS_API_KEY env var", func(t *testing.T) {
+		t.Setenv("SCANOSS_API_KEY", "env-api-key")
+		cfg := initConfigWithApiArgs(t, "cli-api-key", "")
+		assert.Equal(t, "cli-api-key", cfg.GetApiToken())
+	})
+}
+
 func TestInitializePathConfig(t *testing.T) {
 	workDir := "/tmp/workdir"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API configuration can be supplied via environment variables (SCANOSS_API_KEY, SCANOSS_SCAN_URL).
  * CLI arguments continue to take precedence over environment variables.

* **Tests**
  * Added tests covering API configuration behavior, including env var support and CLI override scenarios.

* **Documentation**
  * Changelog updated with the 0.13.2 entry noting environment variable support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scanoss/scanoss.cc/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->