### PR TITLE
docs: SP-4454 fix dead Linux download links

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -222,7 +222,7 @@ The script automatically:
 SCANOSS Code Compare provides two Linux binaries to support different WebKit versions:
 
 - **Ubuntu 24.04+ / Debian 13+**: Download `scanoss-cc-linux-amd64-webkit41.zip`
-- **All other systems**: Download `scanoss-cc-linux-amd64.zip`
+- **All other systems**: Download `scanoss-cc-linux-amd64-webkit40.zip`
 
 #### Installation Steps
 
@@ -232,8 +232,8 @@ SCANOSS Code Compare provides two Linux binaries to support different WebKit ver
 
 **For Ubuntu 22.04 and older / Debian 12 and older:**
 ```bash
-unzip scanoss-cc-linux-amd64.zip
-sudo mv scanoss-cc-linux-amd64 /usr/local/bin/scanoss-cc
+unzip scanoss-cc-linux-amd64-webkit40.zip
+sudo mv scanoss-cc-linux-amd64-webkit40 /usr/local/bin/scanoss-cc
 ```
 
 **For Ubuntu 24.04+ / Debian 13+:**

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ See [INSTALLATION.md](INSTALLATION.md) for PATH setup and installation to Progra
 <summary><b>Linux</b></summary>
 
 Choose the appropriate binary for your system from the [releases page](https://github.com/scanoss/scanoss.cc/releases):
-- **Ubuntu 22.04 and older / Debian 12 and older**: [scanoss-cc-linux-amd64.zip](https://github.com/scanoss/scanoss.cc/releases/latest/download/scanoss-cc-linux-amd64.zip)
+- **Ubuntu 22.04 and older / Debian 12 and older**: [scanoss-cc-linux-amd64-webkit40.zip](https://github.com/scanoss/scanoss.cc/releases/latest/download/scanoss-cc-linux-amd64-webkit40.zip)
 - **Ubuntu 24.04+ / Debian 13+**: [scanoss-cc-linux-amd64-webkit41.zip](https://github.com/scanoss/scanoss.cc/releases/latest/download/scanoss-cc-linux-amd64-webkit41.zip)
 
 Extract and run:
 ```bash
 # For Ubuntu 22.04 and older
-unzip scanoss-cc-linux-amd64.zip
-sudo mv scanoss-cc-linux-amd64 /usr/local/bin/scanoss-cc
+unzip scanoss-cc-linux-amd64-webkit40.zip
+sudo mv scanoss-cc-linux-amd64-webkit40 /usr/local/bin/scanoss-cc
 
 # For Ubuntu 24.04+ (webkit 4.1)
 unzip scanoss-cc-linux-amd64-webkit41.zip


### PR DESCRIPTION
The webkit matrix builds renamed the Linux asset from scanoss-cc-linux-amd64.zip to scanoss-cc-linux-amd64-webkit40.zip, but README.md and INSTALLATION.md still pointed to the old name, which now returns 404. Update the download links and the unzip/mv commands.

Ticket: https://scanoss.atlassian.net/browse/SP-4454